### PR TITLE
FTP delete

### DIFF
--- a/models/datasources/ftp_source.php
+++ b/models/datasources/ftp_source.php
@@ -257,7 +257,7 @@ class FtpSource extends DataSource {
  * @return bool
  */
 	public function delete(&$Model, $file=null) {
-		if (empty($file)) {
+		if (empty($file) || is_array($file)) {
 			$file = $Model->id;
 			if (empty($file)) {
 				return false;


### PR DESCRIPTION
Cake lib makes file param in delete method of ftp_source.php array. Quick fix for this is use model id when file is array.
