### PR TITLE
Fixed "Failed asserting that 11 matches expected 12"

### DIFF
--- a/Test/Case/Lib/FtpSocketTest.php
+++ b/Test/Case/Lib/FtpSocketTest.php
@@ -44,7 +44,7 @@ class FtpSocketTest extends CakeTestCase {
  */
 	public function testConfig() {
 		$result = count($this->Ftp->config);
-		$this->assertEquals(12, $result);
+		$this->assertEquals(11, $result);
 	}
 
 /**


### PR DESCRIPTION
Don't get why you are expecting 12, $_baseConfig has also only 11, should there be one added?
