### PR TITLE
Replaced DS with literal '/'

### DIFF
--- a/Controller/ClientController.php
+++ b/Controller/ClientController.php
@@ -88,7 +88,7 @@ class ClientController extends FtpAppController {
 	public function upload() {
 		if (!empty($this->request->data['File']) && $this->connected) {
 			try {
-				$remote = $this->request->data['File']['path'] . DS . $this->request->data['File']['file']['name'];
+				$remote = $this->request->data['File']['path'] . '/' . $this->request->data['File']['file']['name'];
 				if ($this->Ftp->save(array(
 					'local' => $this->request->data['File']['file']['tmp_name'],
 					'remote' => $remote,


### PR DESCRIPTION
I think there is no reason to use DS.
The opposite, because DS is dependend on the local OS.
So on Windows we would get a \ instead of a / which breaks not only the test...
But please verify first ;-)
