### PR TITLE
Replaced DS with literal '/'

### DIFF
--- a/Model/Datasource/FtpSource.php
+++ b/Model/Datasource/FtpSource.php
@@ -440,7 +440,7 @@ class FtpSource extends DataSource {
 		$out = array();
 		foreach ($rawlist as $file => $data) {
 			$out[] = array(
-				'path'		=> $path . DS,
+				'path'		=> $path . '/',
 				'filename'	=> $file,
 				'is_dir'	=> ($data['type'] === NET_SFTP_TYPE_DIRECTORY),
 				'is_link'	=> ($data['type'] === NET_SFTP_TYPE_SYMLINK),


### PR DESCRIPTION
Just like in the last pull request https://github.com/shama/cakeftp/pull/16 using DS only breaks the code on Windows (to my understanding).
Again verify please
