### PR TITLE
Fixed broken date test

### DIFF
--- a/Test/Case/Model/Datasource/FtpSourceTest.php
+++ b/Test/Case/Model/Datasource/FtpSourceTest.php
@@ -277,7 +277,7 @@ END
 		$this->assertEqual($result[0]['is_link'], '0');
 		$this->assertEqual($result[0]['size'], '4096');
 		$this->assertEqual($result[0]['chmod'], '750');
-		$this->assertEqual($result[0]['mtime'], '2012-07-12 12:16:00');
+		$this->assertEqual($result[0]['mtime'], date('Y') . '-07-12 12:16:00');
 		$this->assertEqual($result[0]['raw'], 'drwxr-x---   3 kyle  group      4096 Jul 12 12:16 public_ftp');
 
 		// FILENAME WITH SPACES IN IT?


### PR DESCRIPTION
Test ist broken because literal 2012 was used instead of dynamic year
