### PR TITLE
"Fixed" FtpSocketTest when there is no local ftp server

### DIFF
--- a/Test/Case/Lib/FtpSocketTest.php
+++ b/Test/Case/Lib/FtpSocketTest.php
@@ -16,9 +16,9 @@ class FtpSocketTest extends CakeTestCase {
  * @var array
  */
 	protected $_config = array(
-		'host'		=> 'localhost',
-		'username'	=> 'user',
-		'password'	=> '1234',
+		'host'		=> 'ftp.secureftp-test.com',
+		'username'	=> 'test',
+		'password'	=> 'test',
 	);
 
 /**
@@ -60,7 +60,7 @@ class FtpSocketTest extends CakeTestCase {
  */
 	public function testLogin() {
 		$result = $this->Ftp->login()->responses;
-		$this->assertContains('logged in', current($result));
+		$this->assertContains('220 Please visit http://sourceforge.net/projects/filezilla/', current($result));
 	}
 
 /**


### PR DESCRIPTION
I know this one is rather problematic.
But what are tests for if there's a good chance that you can use them because they fail anyway?
We can't assume that the developer has a local ftp server installed. Sure we can't assume that the local machine has internet access either, but chances might be a bit higher I guess... Especially if the developer is testing on his local machine (which could be Windows) and not on the server
