### PR TITLE
Remove invalid arg

### DIFF
--- a/Model/Datasource/FtpSource.php
+++ b/Model/Datasource/FtpSource.php
@@ -147,7 +147,7 @@ class FtpSource extends DataSource {
 						throw new Exception(__d('cakeftp', 'Folder does not exist'));
 					}
 					$path = $this->_ftp('ftp_pwd', array($this->config['connection']));
-					$raw = $this->_ftp('ftp_rawlist', array($this->config['connection'], "-A .", $recursive));
+					$raw = $this->_ftp('ftp_rawlist', array($this->config['connection'], ".", $recursive));
 					if (method_exists($model, 'parseFtpResults')) {
 						$out = $model->parseFtpResults($raw, $path, $this->config);
 					} else {


### PR DESCRIPTION
The FTP List command only accepts an optional path argument, the '-A' flag is not in the standard.

RFC 959: https://www.ietf.org/rfc/rfc959.txt
LIST usage from section 5.3.1: "LIST [<SP> <pathname>] <CRLF>"